### PR TITLE
refactor: add default gpg-agent conf

### DIFF
--- a/gnupg/gpg-agent.conf
+++ b/gnupg/gpg-agent.conf
@@ -1,0 +1,7 @@
+# Enables GPG to find gpg-agent
+
+# Connects gpg-agent to the OSX keychain via the brew-installed
+# pinentry program from GPGtools. This is the OSX 'magic sauce',
+# allowing the gpg key's passphrase to be stored in the login
+# keychain, enabling automatic key signing.
+pinentry-program /usr/local/bin/pinentry-mac


### PR DESCRIPTION
This MR adds a default configuration for the GnuPG gpg-agent.