### PR TITLE
refactor: change tmux prefix to ctrl + a

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -5,11 +5,15 @@
 # nvim compatibility - fix the cursor problem
 set -g -a terminal-overrides ',*:Ss=\E[%p1%d q:Se=\E[2 q'
 
-# set prefix to Ctrl-Space
-# unbind C-b
-# set -g prefix C-Space
+# Use Ctrl+A as the prefix key
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
 
-# force a reload of the config file
+# Keep your finger on ctrl, or don't
+bind-key ^D detach-client
+
+# Make `Ctrl+A R` reload the config file
 unbind r
 bind r source-file "$TMUXDIR/tmux.conf" \; display "Reloaded tmux conf"
 


### PR DESCRIPTION
This MR changes the Tmux prefix to be Ctrl + A.